### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,6 +19,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   private
 
   def item_params

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,7 +127,7 @@
     <ul class='item-lists'>
       <% @items.each do |item| %> 
         <li class='list' >
-         <%=link_to "#" do %> 
+         <%=link_to item_path(item.id) do %> 
           <div class="item-img-content" >
            <div class= "item-img" >
             <%=image_tag item.image.variant(resize:'250x250') if item.image.attached? %> 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outの表示をしましょう。 %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -16,7 +16,7 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price %>円
       </span>
       <span class="item-postage">
         (税込) 送料込み
@@ -42,27 +42,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.delivery_burden.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.shipping_area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.estimated_shipping.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,17 +23,16 @@
       </span>
     </div>
 
-    <%# ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
+   <% if user_signed_in? && current_user.id == @item.user_id %>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+   <% else %>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+   <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
 
-    <%# //ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,5 @@ Rails.application.routes.draw do
 
   root to:  "items#index"
   resources :items 
-
   resources :users
 end


### PR DESCRIPTION
WHAT
ログアウト状態でもブラウザで商品詳細ページを閲覧できるよう実装
出品者にしか商品の編集・削除のリンクが踏めないよう実装
出品者以外（且つログインしたユーザー）のみ商品購入のリンクが踏めるよう実装
商品出品時に登録した情報が見られるよう実装


WHY
最終課題フリマアプリの商品詳細表示機能実装のため


画像
出品者以外（且つログインしたユーザー）のみ商品購入のリンクが踏めるよう実装
https://gyazo.com/69122b2531a52a4f093da977d9ecea66

出品者にしか商品の編集・削除のリンクが踏めないよう実装　商品出品時に登録した情報が見られるよう実装
https://gyazo.com/046d6bec9fe84a9a2f0264291805eee0

https://gyazo.com/c12dc3d5dc9d5cfff9a127192c4311b8

